### PR TITLE
Allow editing of multiple medical histories and remove tags from Ui

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -50,7 +50,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_NRIC, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_APPOINTMENT, PREFIX_MEDICAL, PREFIX_TAG);
+                PREFIX_ADDRESS, PREFIX_APPOINTMENT);
 
         Name name = null;
         Nric nric = null;
@@ -74,7 +74,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
+                .ifPresent(editPersonDescriptor::setTags);
+
         parseMedicalHistoriesForEdit(argMultimap.getAllValues(PREFIX_MEDICAL))
                 .ifPresent(editPersonDescriptor::setMedicalHistories);
 
@@ -123,5 +125,4 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ? Collections.emptySet() : medicalHistories;
         return Optional.of(ParserUtil.parseMedicals(medicalHistorySet));
     }
-
 }

--- a/src/main/java/seedu/address/model/person/MedicalHistory.java
+++ b/src/main/java/seedu/address/model/person/MedicalHistory.java
@@ -39,7 +39,7 @@ public class MedicalHistory {
 
     @Override
     public String toString() {
-        return value;
+        return '[' + value + ']';
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -64,8 +64,5 @@ public class PersonCard extends UiPart<Region> {
         person.getMedicalHistories().stream()
                 .sorted(Comparator.comparing(medicalHistory -> medicalHistory.value))
                 .forEach(medicalHistory -> medicalHistories.getChildren().add(new Label(medicalHistory.value)));
-        person.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -337,12 +337,12 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#medicalHistories {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#tags .label {
+#medicalHistories .label {
     -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,12 +28,10 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
         <Label fx:id="nric" styleClass="cell_small_label" text="\$nric" />
       </HBox>
-      <FlowPane fx:id="tags" />
       <FlowPane fx:id="medicalHistories" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-<!--      <Label fx:id="medicalHistories" styleClass="cell_small_label" text="\$medicalHistory" />-->
       <Label fx:id="appointment" styleClass="cell_small_label" text="\$appointment" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
In this commit, edit now works with multiple m/ tags
The personCard is also updated such that tags are removed and medical history now has identical Ui as the tags.

Resolves #69 