### PR TITLE
Add Undo Command Implementation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -68,6 +68,7 @@ public class AddCommand extends UndoableCommand {
         }
 
         model.addPerson(toAdd);
+        model.addToHistory(this);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -47,7 +47,7 @@ public class AddCommand extends UndoableCommand {
     public static final String MESSAGE_SUCCESS = "New Patient added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This Patient already exists in the address book";
 
-    public static final String MESSAGE_UNDO_ADD_SUCCESS = "Reverted the adding of Patient: ";
+    public static final String MESSAGE_UNDO_ADD_SUCCESS = "Undoing the adding of Patient:  %1$s";
 
     private final Person toAdd;
 
@@ -75,7 +75,6 @@ public class AddCommand extends UndoableCommand {
     @Override
     public CommandResult undo(Model model) {
         requireNonNull(model);
-
         model.deletePerson(toAdd);
         return new CommandResult(String.format(MESSAGE_UNDO_ADD_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -19,11 +19,11 @@ import seedu.address.model.person.Person;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the patient list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a Patient to the patient list. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_NRIC + "NRIC "
@@ -44,8 +44,10 @@ public class AddCommand extends Command {
             + PREFIX_MEDICAL + "on Medicine XYZ "
             + PREFIX_TAG + "owesMoney";
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_SUCCESS = "New Patient added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This Patient already exists in the address book";
+
+    public static final String MESSAGE_UNDO_ADD_SUCCESS = "Reverted the adding of Patient: ";
 
     private final Person toAdd;
 
@@ -67,6 +69,14 @@ public class AddCommand extends Command {
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+    }
+
+    @Override
+    public CommandResult undo(Model model) {
+        requireNonNull(model);
+
+        model.deletePerson(toAdd);
+        return new CommandResult(String.format(MESSAGE_UNDO_ADD_SUCCESS, Messages.format(toAdd)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -46,7 +46,6 @@ public class AddCommand extends UndoableCommand {
 
     public static final String MESSAGE_SUCCESS = "New Patient added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This Patient already exists in the address book";
-
     public static final String MESSAGE_UNDO_ADD_SUCCESS = "Undoing the adding of Patient:  %1$s";
 
     private final Person toAdd;

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,7 +12,7 @@ public class ClearCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "HealthSync has been cleared!";
-    public static final String MESSAGE_UNDO_SUCCESS = "Reverted the clearing of HealthSync";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undoing the clearing of HealthSync data.";
 
     private AddressBook addressBookBeforeClear;
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,7 +12,7 @@ public class ClearCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "HealthSync has been cleared!";
-    public static final String MESSAGE_UNDO_SUCCESS = "Undoing the clearing of HealthSync data.";
+    public static final String MESSAGE_UNDO_CLEAR_SUCCESS = "Undoing the clearing of HealthSync data.";
 
     private AddressBook addressBookBeforeClear;
 
@@ -31,6 +31,6 @@ public class ClearCommand extends UndoableCommand {
     public CommandResult undo(Model model) {
         requireNonNull(model);
         model.setAddressBook(addressBookBeforeClear);
-        return new CommandResult(MESSAGE_UNDO_SUCCESS);
+        return new CommandResult(MESSAGE_UNDO_CLEAR_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -8,16 +8,28 @@ import seedu.address.model.Model;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "HealthSync has been cleared!";
+    public static final String MESSAGE_UNDO_SUCCESS = "Reverted the clearing of HealthSync";
 
+    private AddressBook addressBookBeforeClear;
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
+        // Store a copy of the current address book before clearing
+        addressBookBeforeClear = new AddressBook(model.getAddressBook());
+
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+    @Override
+    public CommandResult undo(Model model) {
+        requireNonNull(model);
+        model.setAddressBook(addressBookBeforeClear);
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -22,6 +22,7 @@ public class ClearCommand extends UndoableCommand {
 
         // Store a copy of the current address book before clearing
         addressBookBeforeClear = new AddressBook(model.getAddressBook());
+        model.addToHistory(this);
 
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,9 +41,9 @@ public class DeleteCommand extends UndoableCommand {
     public static final String MESSAGE_PERSON_NOT_FOUND =
             "The given combination of Name and NRIC does not match any patient in the patients list.";
 
-    public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Reverted the deletion of Patient: ";
+    public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Undoing the deletion of Patient:  %1$s";
 
-    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCESS = "Reverted the deletion of a Patient's field: ";
+    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCESS = "Undoing the deletion of a Patient's field:  %1$s";
 
     /**
      * The original state of the person.
@@ -102,12 +102,15 @@ public class DeleteCommand extends UndoableCommand {
         if (deletePersonDescriptor.isAllFalse()) {
             model.addPerson(originalPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS, Messages.format(originalPerson)));
+            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS,
+                    Messages.format(originalPerson)));
         } else {
             Person personToDelete = editedPerson;
             model.setPerson(personToDelete, originalPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_FIELD_SUCESS, Messages.format(originalPerson)));
+            System.out.println(originalPerson);
+            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_FIELD_SUCESS,
+                    Messages.format(editedPerson)));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,7 +41,7 @@ public class DeleteCommand extends UndoableCommand {
     public static final String MESSAGE_PERSON_NOT_FOUND =
             "The given combination of Name and NRIC does not match any patient in the patients list.";
 
-    public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Undoing the deletion of Patient:  %1$s";
+    public static final String MESSAGE_UNDO_DELETE_PERSON_SUCCESS = "Undoing the deletion of Patient:  %1$s";
 
     public static final String MESSAGE_UNDO_DELETE_FIELD_SUCCESS = "Undoing the deletion of a Patient's field:  %1$s";
 
@@ -102,13 +102,12 @@ public class DeleteCommand extends UndoableCommand {
         if (deletePersonDescriptor.isAllFalse()) {
             model.addPerson(originalPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS,
+            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_PERSON_SUCCESS,
                     Messages.format(originalPerson)));
         } else {
             Person personToDelete = editedPerson;
             model.setPerson(personToDelete, originalPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            System.out.println(originalPerson);
             return new CommandResult(String.format(MESSAGE_UNDO_DELETE_FIELD_SUCCESS,
                     Messages.format(editedPerson)));
         }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -81,18 +81,17 @@ public class DeleteCommand extends UndoableCommand {
         }
 
         Person personToDelete = personOptional.get();
-
         originalPerson = personToDelete;
 
         if (deletePersonDescriptor.isAllFalse()) {
-            model.addToHistory(this);
             model.deletePerson(personToDelete);
+            model.addToHistory(this);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         } else {
             editedPerson = createDeletePerson(personToDelete, deletePersonDescriptor);
-            model.addToHistory(this);
             model.setPerson(personToDelete, editedPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.addToHistory(this);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_FIELD_SUCCESS, Messages.format(editedPerson)));
         }
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -34,16 +34,16 @@ public class DeleteCommand extends UndoableCommand {
             + "Parameters: n/Name or id/Nric (must be valid)\n"
             + "Example: " + COMMAND_WORD + " n/John Doe or " + COMMAND_WORD + " id/S1234567A";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Patient: %1$s";
 
-    public static final String MESSAGE_DELETE_PERSON_FIELD_SUCCESS = "Deleted Person's field: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_FIELD_SUCCESS = "Deleted Patient's field: %1$s";
 
     public static final String MESSAGE_PERSON_NOT_FOUND =
-            "The given combination of Name and NRIC does not match any person in the patients list.";
+            "The given combination of Name and NRIC does not match any patient in the patients list.";
 
-    public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Reverted the deletion of: ";
+    public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Reverted the deletion of Patient: ";
 
-    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCESS = "Reverted the deletion of patient with a field: ";
+    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCESS = "Reverted the deletion of a Patient's field: ";
 
     /**
      * The original state of the person.
@@ -57,9 +57,6 @@ public class DeleteCommand extends UndoableCommand {
     private final Name name;
     private final Nric nric;
     private final DeletePersonDescriptor deletePersonDescriptor;
-
-
-
 
     /**
      * @param nric of the person in the filtered person list to edit

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -43,7 +43,7 @@ public class DeleteCommand extends UndoableCommand {
 
     public static final String MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS = "Undoing the deletion of Patient:  %1$s";
 
-    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCESS = "Undoing the deletion of a Patient's field:  %1$s";
+    public static final String MESSAGE_UNDO_DELETE_FIELD_SUCCESS = "Undoing the deletion of a Patient's field:  %1$s";
 
     /**
      * The original state of the person.
@@ -109,7 +109,7 @@ public class DeleteCommand extends UndoableCommand {
             model.setPerson(personToDelete, originalPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             System.out.println(originalPerson);
-            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_FIELD_SUCESS,
+            return new CommandResult(String.format(MESSAGE_UNDO_DELETE_FIELD_SUCCESS,
                     Messages.format(editedPerson)));
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -36,19 +36,19 @@ public class EditCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the name or NRIC of the patient.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the Person identified "
+            + "by the name or NRIC of the Patient.\n"
             + "Existing values will be overwritten by the input values.\n"
             + "Format: edit n/NAME or id/IC_NUMBER [Fields] ...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "91234567";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_UNDO_PERSON_SUCESS = "Undo Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Patient: %1$s";
+    public static final String MESSAGE_UNDO_PERSON_SUCCESS = "Reverted the Editing of Patient:";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. Example: p/98742122.";
     public static final String MESSAGE_PERSON_NOT_FOUND =
-            "The given combination of Name and/or NRIC does not match any person in the patients list.";
+            "The given combination of Name and/or NRIC does not match any person in the Patient list.";
 
 
     private static final Logger logger = Logger.getLogger(EditCommand.class.getName());
@@ -111,7 +111,7 @@ public class EditCommand extends UndoableCommand {
         model.setPerson(editedPerson, originalPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_UNDO_PERSON_SUCESS, Messages.format(originalPerson)));
+        return new CommandResult(String.format(MESSAGE_UNDO_PERSON_SUCCESS, Messages.format(originalPerson)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -101,7 +101,6 @@ public class EditCommand extends UndoableCommand {
         logger.log(Level.INFO, "EditCommand executed successfully");
 
         model.addToHistory(this);
-
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -100,7 +100,6 @@ public class EditCommand extends UndoableCommand {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         logger.log(Level.INFO, "EditCommand executed successfully");
 
-        // Add to Stack of Commands
         model.addToHistory(this);
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -83,7 +83,6 @@ public class EditCommand extends UndoableCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-
         Optional<Person> personOptional = CommandUtil.findPersonByIdentifier(name, nric, lastShownList);
 
         if (personOptional.isEmpty()) {
@@ -100,6 +99,9 @@ public class EditCommand extends UndoableCommand {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         logger.log(Level.INFO, "EditCommand executed successfully");
+
+        // Add to Stack of Commands
+        model.addToHistory(this);
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. Example: p/98742122.";
     public static final String MESSAGE_PERSON_NOT_FOUND =
-            "The given combination of Name and NRIC does not match any person in the patients list.";
+            "The given combination of Name and/or NRIC does not match any person in the patients list.";
     private static final Logger logger = Logger.getLogger(EditCommand.class.getName());
 
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,7 +45,7 @@ public class EditCommand extends UndoableCommand {
             + PREFIX_PHONE + "91234567";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Patient: %1$s";
-    public static final String MESSAGE_UNDO_PERSON_SUCCESS = "Undoing the Editing of Patient:  %1$s";
+    public static final String MESSAGE_UNDO_EDIT_PERSON_SUCCESS = "Undoing the Editing of Patient:  %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n"
             + "Fields include phone (p/), email (e/), "
             + "address (a/), appointment (ap/) and medical history (m/)\n"
@@ -112,7 +112,7 @@ public class EditCommand extends UndoableCommand {
         model.setPerson(editedPerson, originalPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_UNDO_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_UNDO_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,11 +45,13 @@ public class EditCommand extends UndoableCommand {
             + PREFIX_PHONE + "91234567";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Patient: %1$s";
-    public static final String MESSAGE_UNDO_PERSON_SUCCESS = "Reverted the Editing of Patient:";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. Example: p/98742122.";
-    public static final String MESSAGE_PERSON_NOT_FOUND =
-            "The given combination of Name and/or NRIC does not match any person in the Patient list.";
-
+    public static final String MESSAGE_UNDO_PERSON_SUCCESS = "Undoing the Editing of Patient:  %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n"
+            + "Fields include phone (p/), email (e/), "
+            + "address (a/), appointment (ap/) and medical history (m/)\n"
+            + "Name and NRIC cannot be edited\n";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "INVALID name and/or Nric!\n"
+            + "The given combination of Name and/or NRIC does not match any person in the Patient list.";
 
     private static final Logger logger = Logger.getLogger(EditCommand.class.getName());
 
@@ -110,7 +112,7 @@ public class EditCommand extends UndoableCommand {
         model.setPerson(editedPerson, originalPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_UNDO_PERSON_SUCCESS, Messages.format(originalPerson)));
+        return new CommandResult(String.format(MESSAGE_UNDO_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting HealthSync as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,7 +19,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all Patients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example 1: " + COMMAND_WORD + " n/alice bob charlie \n"

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all Patients";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -24,9 +24,11 @@ public class UndoCommand extends Command {
 
     public static final String INVALID_NEGATIVE_STEPS_TO_UNDO = "Undo step count cannot be a negative number.";
 
-    public static final String INVALID_POSITIVE_STEPS_TO_UNDO = "Please provide a valid number of steps to undo, " +
-            "not exceeding the available command history";
+    public static final String INVALID_POSITIVE_STEPS_TO_UNDO = "Please provide a valid number of steps to undo, "
+            + "not exceeding the available command history";
 
+    public static final String NO_HISTORY_EXISTS_FAILURE = "There is no history of un-doable commands to be undone. "
+            + "Please execute some undo-able commands first.";
     private int stepsToUndo;
 
     /**
@@ -48,10 +50,15 @@ public class UndoCommand extends Command {
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        if (model.getCommandHistorySize() == 0) {
+            throw new CommandException(NO_HISTORY_EXISTS_FAILURE);
+        }
         if (stepsToUndo > model.getCommandHistorySize()) {
             throw new CommandException(INVALID_POSITIVE_STEPS_TO_UNDO +
-                    "(Currently max is: " + model.getCommandHistorySize());
+                    " (Currently max is: " + model.getCommandHistorySize() + ")");
         }
+
+        assert stepsToUndo <= model.getCommandHistorySize();
 
         List<String> undoStatus = new ArrayList<>();
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,4 +1,68 @@
 package seedu.address.logic.commands;
 
-public class UndoCommand {
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents an undo command in the address book.
+ * This undoes the last undo-able command, which includes edit, add, or delete commands.
+ * Optionally, you can specify the number of commands to undo.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the last undo-able command. "
+            + "An undo-able command includes an edit, add, or delete command. "
+            + "Optionally, you can specify the number of commands to undo.\n"
+            + "Format: " + COMMAND_WORD + " [number]\n"
+            + "Examples:\n"
+            + " - " + COMMAND_WORD + " (undoes the last command)\n"
+            + " - " + COMMAND_WORD + " 4 (undoes the last 4 commands)";
+
+    public static final String INVALID_NEGATIVE_STEPS_TO_UNDO = "Undo step count cannot be a negative number.";
+
+    public static final String INVALID_POSITIVE_STEPS_TO_UNDO = "Please provide a valid number of steps to undo, " +
+            "not exceeding the available command history";
+
+    private int stepsToUndo;
+
+    /**
+     * Constructs an UndoCommand for the specified number of undo steps.
+     *
+     * @param stepsToUndo The number of steps to undo.
+     */
+    public UndoCommand(int stepsToUndo) {
+        assert stepsToUndo > 0;
+        this.stepsToUndo = stepsToUndo;
+    }
+
+    /**
+     * Executes the undo command based on the number of steps provided.
+     *
+     * @param model The model where the undo operation will be applied.
+     * @return A CommandResult encapsulating the status of the undo operation.
+     * @throws CommandException If the number of steps to undo exceeds the available command history size.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        if (stepsToUndo > model.getCommandHistorySize()) {
+            throw new CommandException(INVALID_POSITIVE_STEPS_TO_UNDO +
+                    "(Currently max is: " + model.getCommandHistorySize());
+        }
+
+        List<String> undoStatus = new ArrayList<>();
+
+        while (stepsToUndo != 0) {
+            UndoableCommand undoableCommand = model.popCommandFromHistory();
+            CommandResult result = undoableCommand.undo(model);
+            undoStatus.add(result.getFeedbackToUser());
+            stepsToUndo--;
+        }
+
+        String combinedStatus = String.join("\n", undoStatus);
+        return new CommandResult("Undoing command(s):\n" + combinedStatus);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,2 +1,4 @@
-package seedu.address.logic.commands;public class UndoCommand {
+package seedu.address.logic.commands;
+
+public class UndoCommand {
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class UndoCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -44,6 +44,7 @@ public class UndoCommand extends Command {
      * @param stepsToUndo The number of steps to undo.
      */
     public UndoCommand(int stepsToUndo) {
+        assert stepsToUndo > 0;
         this.stepsToUndo = stepsToUndo;
     }
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -15,7 +15,7 @@ public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the last undo-able command. "
-            + "An undo-able command includes an edit, add, or delete command. "
+            + "An undo-able command includes an edit, add, clear or delete command. "
             + "Optionally, you can specify the number of commands to undo.\n"
             + "Format: " + COMMAND_WORD + " [number]\n"
             + "Examples:\n"

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -25,10 +25,9 @@ public class UndoCommand extends Command {
             + "An undo-able command includes an edit, add, clear or delete command.\n"
             + "Optionally, you can specify the number of commands to undo.\n"
             + COMMAND_FORMAT;
-    public static final String INVALID_NEGATIVE_STEPS_TO_UNDO = "Undo step count cannot be a negative number.\n"
-            + MESSAGE_USAGE;
+    public static final String INVALID_STEPS_TO_UNDO = "Undo step count cannot be a negative number or zero.\n";
 
-    public static final String INVALID_POSITIVE_STEPS_TO_UNDO = "Please provide a valid number of steps to undo, "
+    public static final String INVALID_NATURAL_NUMBER_TO_UNDO = "Please provide a valid number of steps to undo, "
             + "not exceeding the available command history";
 
     public static final String NO_HISTORY_EXISTS_FAILURE = "There is no history of un-doable commands to be undone.\n"
@@ -64,7 +63,7 @@ public class UndoCommand extends Command {
         }
         if (stepsToUndo > model.getCommandHistorySize()) {
             logger.log(Level.WARNING, "Invalid steps to undo");
-            throw new CommandException(INVALID_POSITIVE_STEPS_TO_UNDO
+            throw new CommandException(INVALID_NATURAL_NUMBER_TO_UNDO
                     + " (Currently max is: " + model.getCommandHistorySize() + ").\n"
                     + MESSAGE_USAGE);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -83,5 +84,16 @@ public class UndoCommand extends Command {
 
         String combinedStatus = String.join("\n", undoStatus);
         return new CommandResult("Undoing " + (counter - 1) + " command(s):\n" + combinedStatus);
+    }
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof UndoCommand)) {
+            return false;
+        }
+        UndoCommand that = (UndoCommand) object;
+        return stepsToUndo == that.stepsToUndo;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -44,7 +44,6 @@ public class UndoCommand extends Command {
      * @param stepsToUndo The number of steps to undo.
      */
     public UndoCommand(int stepsToUndo) {
-        assert stepsToUndo > 0;
         this.stepsToUndo = stepsToUndo;
     }
 

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -1,0 +1,16 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public abstract class UndoableCommand extends Command {
+    /**
+     * Reverts the effects of the command.
+     *
+     * @param model {@code Model} which the undo command should operate on.
+     * @return feedback message of the undo result for display
+     * @throws CommandException If an error occurs during the undo operation.
+     */
+    public abstract CommandResult undo(Model model) throws CommandException;
+
+}

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -3,6 +3,10 @@ package seedu.address.logic.commands;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
+/**
+ * Represents a command that can be undone. Subclasses of this abstract class
+ * must provide an implementation for the undo operation.
+ */
 public abstract class UndoableCommand extends Command {
     /**
      * Reverts the effects of the command.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -26,9 +26,9 @@ public class UndoCommandParser implements Parser<UndoCommand> {
         } else {
             try {
                 int steps = Integer.parseInt(trimmedArgs);
-                if (steps < 0) {
+                if (steps <= 0) {
                     throw new ParseException(String.format(
-                            UndoCommand.INVALID_NEGATIVE_STEPS_TO_UNDO, UndoCommand.MESSAGE_USAGE));
+                            UndoCommand.INVALID_STEPS_TO_UNDO));
                 } else {
                     return new UndoCommand(steps);
                 }

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,2 +1,4 @@
-package seedu.address.logic.parser;public class UndoCommandParser {
+package seedu.address.logic.parser;
+
+public class UndoCommandParser {
 }

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,4 +1,38 @@
 package seedu.address.logic.parser;
 
-public class UndoCommandParser {
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UndoCommand object.
+ */
+public class UndoCommandParser implements Parser<UndoCommand> {
+
+    /**
+     * Parses the given {@code args} and generates an UndoCommand object.
+     *
+     * @param args User input string.
+     * @return UndoCommand object.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    @Override
+    public UndoCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            return new UndoCommand(1);
+        } else {
+            try {
+                int steps = Integer.parseInt(trimmedArgs);
+                if (steps < 0) {
+                    throw new ParseException(UndoCommand.INVALID_NEGATIVE_STEPS_TO_UNDO);
+                } else {
+                    return new UndoCommand(steps);
+                }
+            } catch (NumberFormatException e) {
+                throw new ParseException(UndoCommand.MESSAGE_USAGE);
+            }
+        }
+    }
 }
+

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class UndoCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -25,12 +27,14 @@ public class UndoCommandParser implements Parser<UndoCommand> {
             try {
                 int steps = Integer.parseInt(trimmedArgs);
                 if (steps < 0) {
-                    throw new ParseException(UndoCommand.INVALID_NEGATIVE_STEPS_TO_UNDO);
+                    throw new ParseException(String.format(
+                            UndoCommand.INVALID_NEGATIVE_STEPS_TO_UNDO, UndoCommand.MESSAGE_USAGE));
                 } else {
                     return new UndoCommand(steps);
                 }
             } catch (NumberFormatException e) {
-                throw new ParseException(UndoCommand.MESSAGE_USAGE);
+                throw new ParseException(String.format(
+                        MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
             }
         }
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -99,6 +99,13 @@ public interface Model {
      */
     UndoableCommand popCommandFromHistory();
 
+    /**
+     * Gets the size of the stack of commandHistory.
+     *
+     * @return The size of the stack of commandHistory.
+     */
+    int getCommandHistorySize();
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.model.person.Person;
 
 /**
@@ -76,6 +77,27 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Adds an {@code UndoableCommand} to the command history stack.
+     *
+     * @param command The undoable command to be added to the command history stack.
+     */
+    void addToHistory(UndoableCommand command);
+
+    /**
+     * Checks if the command history stack is empty.
+     *
+     * @return {@code true} if the command history stack is empty, {@code false} otherwise.
+     */
+    boolean isCommandHistoryEmpty();
+
+    /**
+     * Pops an {@code UndoableCommand} from the command history stack.
+     *
+     * @return The {@code UndoableCommand} popped from the command history stack.
+     */
+    UndoableCommand popCommandFromHistory();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -11,6 +11,7 @@ import seedu.address.model.person.Person;
  * The API of the Model component.
  */
 public interface Model {
+
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -11,6 +12,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.model.person.Person;
 
 /**
@@ -18,6 +20,11 @@ import seedu.address.model.person.Person;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+    /**
+     * Stack to maintain the history of executed undoable commands.
+     */
+    private final Stack<UndoableCommand> commandHistory = new Stack<>();
+
 
     private final AddressBook addressBook;
     private final LogBook logBook;
@@ -114,6 +121,34 @@ public class ModelManager implements Model {
 
         addressBook.setPerson(target, editedPerson);
     }
+
+    /**
+     * Adds an {@code UndoableCommand} to the command history stack.
+     *
+     * @param command The undoable command to be added to the command history stack.
+     */
+    public void addToHistory(UndoableCommand command) {
+        commandHistory.push(command);
+    }
+
+    /**
+     * Checks if the command history stack is empty.
+     *
+     * @return {@code true} if the command history stack is empty, {@code false} otherwise.
+     */
+    public boolean isCommandHistoryEmpty() {
+        return commandHistory.isEmpty();
+    }
+
+    /**
+     * Pops an {@code UndoableCommand} from the command history stack.
+     *
+     * @return The {@code UndoableCommand} popped from the command history stack.
+     */
+    public UndoableCommand popCommandFromHistory() {
+        return commandHistory.pop();
+    }
+
 
     //=========== Filtered Person List Accessors =============================================================
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -124,7 +124,6 @@ public class ModelManager implements Model {
 
     //=========== Undo ======================================================================================
 
-
     @Override
     public void addToHistory(UndoableCommand command) {
         commandHistory.push(command);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -122,29 +122,20 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
-    /**
-     * Adds an {@code UndoableCommand} to the command history stack.
-     *
-     * @param command The undoable command to be added to the command history stack.
-     */
+    //=========== Undo ======================================================================================
+
+
+    @Override
     public void addToHistory(UndoableCommand command) {
         commandHistory.push(command);
     }
 
-    /**
-     * Checks if the command history stack is empty.
-     *
-     * @return {@code true} if the command history stack is empty, {@code false} otherwise.
-     */
+    @Override
     public boolean isCommandHistoryEmpty() {
         return commandHistory.isEmpty();
     }
 
-    /**
-     * Pops an {@code UndoableCommand} from the command history stack.
-     *
-     * @return The {@code UndoableCommand} popped from the command history stack.
-     */
+    @Override
     public UndoableCommand popCommandFromHistory() {
         return commandHistory.pop();
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -141,7 +141,10 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public int getCommandHistorySize() { return commandHistory.size(); }
+    public int getCommandHistorySize() {
+        return commandHistory.size();
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -140,7 +140,8 @@ public class ModelManager implements Model {
         return commandHistory.pop();
     }
 
-
+    @Override
+    public int getCommandHistorySize() { return commandHistory.size(); }
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -25,7 +25,6 @@ public class ModelManager implements Model {
      */
     private final Stack<UndoableCommand> commandHistory = new Stack<>();
 
-
     private final AddressBook addressBook;
     private final LogBook logBook;
     private final UserPrefs userPrefs;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Stack;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -82,6 +83,21 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(ALICE);
         String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
+    }
+
+    @Test
+    public void execute_undo_successful() throws Exception {
+        AddCommand addCommand = new AddCommand(ALICE);
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+
+        addCommand.execute(modelStub);
+        assertTrue(modelStub.hasPerson(ALICE));
+
+        CommandResult undoResult = addCommand.undo(modelStub);
+        assertEquals(String.format(AddCommand.MESSAGE_UNDO_ADD_SUCCESS, Messages.format(ALICE)),
+                undoResult.getFeedbackToUser());
+
+        assertFalse(modelStub.hasPerson(ALICE));
     }
 
     /**
@@ -162,6 +178,26 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void addToHistory(UndoableCommand command) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean isCommandHistoryEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public UndoableCommand popCommandFromHistory() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public int getCommandHistorySize() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**
@@ -187,6 +223,7 @@ public class AddCommandTest {
      */
     private class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
+        private Stack<UndoableCommand> commandHistory = new Stack<>();
 
         @Override
         public boolean hasPerson(Person person) {
@@ -204,6 +241,16 @@ public class AddCommandTest {
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
         }
-    }
 
+        @Override
+        public void addToHistory(UndoableCommand undoableCommand) {
+            this.commandHistory.push(undoableCommand);
+        }
+
+        @Override
+        public void deletePerson(Person person) {
+            requireNonNull(person);
+            personsAdded.remove(person);
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -27,6 +28,40 @@ public class ClearCommandTest {
         expectedModel.setAddressBook(new AddressBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void undo_nonEmptyAddressBook() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model emptyModel = new ModelManager();
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        ClearCommand clearCommand = new ClearCommand();
+
+        // Execute the clear command
+        clearCommand.execute(model);
+        assertEquals(emptyModel, model);
+
+        // Undo the command
+        CommandResult undoResult = clearCommand.undo(model);
+        assertEquals(expectedModel, model);
+        assertEquals(ClearCommand.MESSAGE_UNDO_SUCCESS, undoResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void undo_emptyAddressBook() {
+        Model model = new ModelManager();
+        Model emptyModel = new ModelManager();
+        Model expectedModel = new ModelManager();
+        ClearCommand clearCommand = new ClearCommand();
+
+        // Execute the clear command
+        clearCommand.execute(model);
+        assertEquals(model, emptyModel);
+
+        // Undo the command
+        CommandResult undoResult = clearCommand.undo(model);
+        assertEquals(model, expectedModel);
+        assertEquals(ClearCommand.MESSAGE_UNDO_SUCCESS, undoResult.getFeedbackToUser());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -44,7 +44,7 @@ public class ClearCommandTest {
         // Undo the command
         CommandResult undoResult = clearCommand.undo(model);
         assertEquals(expectedModel, model);
-        assertEquals(ClearCommand.MESSAGE_UNDO_SUCCESS, undoResult.getFeedbackToUser());
+        assertEquals(ClearCommand.MESSAGE_UNDO_CLEAR_SUCCESS, undoResult.getFeedbackToUser());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class ClearCommandTest {
         // Undo the command
         CommandResult undoResult = clearCommand.undo(model);
         assertEquals(model, expectedModel);
-        assertEquals(ClearCommand.MESSAGE_UNDO_SUCCESS, undoResult.getFeedbackToUser());
+        assertEquals(ClearCommand.MESSAGE_UNDO_CLEAR_SUCCESS, undoResult.getFeedbackToUser());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -184,4 +184,43 @@ public class DeleteCommandTest {
                 + "deletePersonDescriptor=" + defaultDescriptor + "}";
         assertEquals(expected, deleteCommand.toString());
     }
+
+    @Test
+    public void undoDeletePerson_success() throws CommandException {
+        Person personToDelete = new PersonBuilder().withName("Amy Bee").build();
+        model.addPerson(personToDelete);
+
+        DeleteCommand deletePersonCommand = new DeleteCommand(null, personToDelete.getName(), defaultDescriptor);
+        deletePersonCommand.execute(model);
+
+        // Undo the deletion of the person
+        CommandResult undoResult = deletePersonCommand.undo(model);
+
+        assertTrue(model.hasPerson(personToDelete));
+        assertEquals(String.format(DeleteCommand.MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS,
+                Messages.format(personToDelete)), undoResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void undoDeleteFields() throws CommandException {
+        Person firstPerson = model.getFilteredPersonList().get(0);
+
+        DeletePersonDescriptor descriptor = new DeletePersonDescriptor();
+        descriptor.setAppointment();
+
+        DeleteCommand deleteFieldsCommand = new DeleteCommand(firstPerson.getNric(), null, descriptor);
+        deleteFieldsCommand.execute(model);
+
+        Person editedPerson = model.getFilteredPersonList().get(0);
+        assertTrue(editedPerson.getAppointment().isEmpty());
+
+        CommandResult undoResult = deleteFieldsCommand.undo(model);
+
+        Person unDonePerson = model.getFilteredPersonList().get(0);
+        assertFalse(unDonePerson.getAppointment().isEmpty());
+
+        assertEquals(String.format(DeleteCommand.MESSAGE_UNDO_DELETE_FIELD_SUCCESS,
+                Messages.format(editedPerson)), undoResult.getFeedbackToUser());
+    }
 }
+

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -197,7 +197,7 @@ public class DeleteCommandTest {
         CommandResult undoResult = deletePersonCommand.undo(model);
 
         assertTrue(model.hasPerson(personToDelete));
-        assertEquals(String.format(DeleteCommand.MESSAGE_UNDO_DELETE_ENTIRE_PERSON_SUCCESS,
+        assertEquals(String.format(DeleteCommand.MESSAGE_UNDO_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete)), undoResult.getFeedbackToUser());
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -33,6 +34,8 @@ import seedu.address.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for the EditCommand.
  */
 public class EditCommandTest {
+
+    private final String nonExistentName = "NonExistentName";
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -112,7 +115,7 @@ public class EditCommandTest {
     public void equals_unequalEditPersonDescriptors_returnsFalse() {
         EditPersonDescriptor descriptor1 = new EditPersonDescriptor();
         EditPersonDescriptor descriptor2 = new EditPersonDescriptor();
-        descriptor1.setName(new Name("Alice"));
+        descriptor1.setName(new Name(VALID_NAME_BOB));
         assertFalse(descriptor1.equals(descriptor2)); // Different name
     }
 
@@ -120,15 +123,15 @@ public class EditCommandTest {
     public void equals_sameObject_returnsTrue() {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(new Name("John Doe"), null, descriptor);
+        EditCommand editCommand = new EditCommand(new Name(VALID_NAME_AMY), null, descriptor);
 
         assertTrue(editCommand.equals(editCommand));
     }
 
     @Test
     public void execute_personNotFound_throwsCommandException() {
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName("NonExistentName").build();
-        EditCommand editCommand = new EditCommand(new Name("NonExistentName"), null, descriptor);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(nonExistentName).build();
+        EditCommand editCommand = new EditCommand(new Name(nonExistentName), null, descriptor);
 
         // The expected CommandException should be thrown with the specified message
         assertThrows(CommandException.class, () -> editCommand.execute(model), EditCommand.MESSAGE_PERSON_NOT_FOUND);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -167,7 +167,8 @@ public class EditCommandTest {
 
         model.addPerson(originalPerson);
 
-        EditCommand editCommand = new EditCommand(originalPerson.getName(), null, new EditCommand.EditPersonDescriptor());
+        EditCommand editCommand = new EditCommand(originalPerson.getName(),
+                null, new EditCommand.EditPersonDescriptor());
         editCommand.execute(model);
 
         Person personAfterEdit = model.getFilteredPersonList().get(0);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -158,4 +158,26 @@ public class EditCommandTest {
         assertEquals(editedPerson.getMedicalHistories(), personToEdit.getMedicalHistories());
         assertEquals(editedPerson.getTags(), personToEdit.getTags());
     }
+
+    @Test
+    public void undo_successfulEditCommand() throws CommandException {
+        Model model = new ModelManager();
+        Person originalPerson = new PersonBuilder().build();
+        Person editedPerson = new PersonBuilder().withName(VALID_NAME_AMY).build();
+
+        model.addPerson(originalPerson);
+
+        EditCommand editCommand = new EditCommand(originalPerson.getName(), null, new EditCommand.EditPersonDescriptor());
+        editCommand.execute(model);
+
+        Person personAfterEdit = model.getFilteredPersonList().get(0);
+        assertEquals(editedPerson, personAfterEdit);
+
+        // Undo the edit
+        UndoableCommand undoCommand = model.popCommandFromHistory();
+        undoCommand.undo(model);
+
+        Person personAfterUndo = model.getFilteredPersonList().get(0);
+        assertEquals(originalPerson, personAfterUndo);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -57,9 +57,8 @@ public class UndoCommandTest {
     }
 
     @Test
-    public void execute_undoMoreCommandsInEmptyStack_failure() {
+    public void execute_undoCommandsInEmptyStack_failure() {
         Model model = new ModelManager();
-        UndoableCommandStub stubUndoableCommand = new UndoableCommandStub();
 
         UndoCommand undoCommand = new UndoCommand(3);
         assertThrows(CommandException.class, () -> undoCommand.execute(model));

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -56,6 +56,15 @@ public class UndoCommandTest {
         assertThrows(CommandException.class, () -> undoCommand.execute(model));
     }
 
+    @Test
+    public void execute_undoMoreCommandsInEmptyStack_failure() {
+        Model model = new ModelManager();
+        UndoableCommandStub stubUndoableCommand = new UndoableCommandStub();
+
+        UndoCommand undoCommand = new UndoCommand(3);
+        assertThrows(CommandException.class, () -> undoCommand.execute(model));
+    }
+
     // Define a stub UndoableCommand class for testing purposes
     static class UndoableCommandStub extends UndoableCommand {
         @Override

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+public class UndoCommandTest {
+
+    @Test
+    public void execute_singleUndoableCommand_success() throws CommandException {
+        Model model = new ModelManager();
+        UndoableCommandStub stubUndoableCommand = new UndoableCommandStub();
+
+        model.addToHistory(stubUndoableCommand);
+
+        UndoCommand undoCommand = new UndoCommand(1);
+        CommandResult result = undoCommand.execute(model);
+
+        assertEquals("Undoing 1 command(s):\n" +
+                "1. Stub Undoable Command undone", result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_multipleUndoableCommand_success() throws CommandException {
+        Model model = new ModelManager();
+        UndoableCommandStub stubUndoableCommand1 = new UndoableCommandStub();
+        UndoableCommandStub stubUndoableCommand2 = new UndoableCommandStub();
+        UndoableCommandStub stubUndoableCommand3 = new UndoableCommandStub();
+
+        model.addToHistory(stubUndoableCommand1);
+        model.addToHistory(stubUndoableCommand2);
+        model.addToHistory(stubUndoableCommand3);
+
+        UndoCommand undoCommand = new UndoCommand(3);
+        CommandResult result = undoCommand.execute(model);
+
+        assertEquals("Undoing 3 command(s):\n" +
+                "1. Stub Undoable Command undone\n" +
+                "2. Stub Undoable Command undone\n" +
+                "3. Stub Undoable Command undone", result.getFeedbackToUser());
+    }
+    @Test
+    public void execute_undoMoreCommandsThanHistory_failure() {
+        Model model = new ModelManager();
+        UndoableCommandStub stubUndoableCommand = new UndoableCommandStub();
+
+        model.addToHistory(stubUndoableCommand);
+
+        // Attempt to undo 2 commands when only 1 is in history
+        UndoCommand undoCommand = new UndoCommand(2);
+        assertThrows(CommandException.class, () -> undoCommand.execute(model));
+    }
+
+    // Define a stub UndoableCommand class for testing purposes
+    static class UndoableCommandStub extends UndoableCommand {
+        @Override
+        public CommandResult execute(Model model) {
+            return new CommandResult("Stub Undoable Command executed");
+        }
+
+        @Override
+        public CommandResult undo(Model model) {
+            return new CommandResult("Stub Undoable Command undone");
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
 
 public class UndoCommandTest {
 
@@ -20,8 +21,8 @@ public class UndoCommandTest {
         UndoCommand undoCommand = new UndoCommand(1);
         CommandResult result = undoCommand.execute(model);
 
-        assertEquals("Undoing 1 command(s):\n" +
-                "1. Stub Undoable Command undone", result.getFeedbackToUser());
+        assertEquals("Undoing 1 command(s):\n"
+                + "1. Stub Undoable Command undone", result.getFeedbackToUser());
     }
 
     @Test
@@ -38,10 +39,10 @@ public class UndoCommandTest {
         UndoCommand undoCommand = new UndoCommand(3);
         CommandResult result = undoCommand.execute(model);
 
-        assertEquals("Undoing 3 command(s):\n" +
-                "1. Stub Undoable Command undone\n" +
-                "2. Stub Undoable Command undone\n" +
-                "3. Stub Undoable Command undone", result.getFeedbackToUser());
+        assertEquals("Undoing 3 command(s):\n"
+                + "1. Stub Undoable Command undone\n"
+                + "2. Stub Undoable Command undone\n"
+                + "3. Stub Undoable Command undone", result.getFeedbackToUser());
     }
     @Test
     public void execute_undoMoreCommandsThanHistory_failure() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -86,6 +87,12 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 3") instanceof UndoCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -58,8 +58,6 @@ public class EditCommandParserTest {
 
     private EditCommandParser parser = new EditCommandParser();
 
-
-
     @Test
     public void parse_missingParts_failure() {
         // no field specified

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -103,38 +103,38 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // phone
-        String userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY;
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
         EditCommand expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + EMAIL_DESC_AMY;
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
-        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + ADDRESS_DESC_AMY;
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + TAG_DESC_FRIEND;
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // medical
-        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + " "
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + " "
                 + PREFIX_MEDICAL + VALID_MEDICALHISTORY;
         descriptor = new EditPersonDescriptorBuilder().withMedicalHistories(VALID_MEDICALHISTORY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // appointment
-        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_AMY + " "
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_AMY + " "
                 + PREFIX_APPOINTMENT + VALID_APPOINTMENT;
         descriptor = new EditPersonDescriptorBuilder().withAppointment(VALID_APPOINTMENT).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_AMY), null, descriptor);
@@ -171,16 +171,16 @@ public class EditCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // mulltiple valid fields repeated
-        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
 
         // multiple invalid values
-        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC
+                + INVALID_EMAIL_DESC + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
@@ -213,13 +213,14 @@ public class EditCommandParserTest {
     public void parse_validInput_returnsEditCommand() throws ParseException {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
         // Valid input with NRIC
-        String validInputWithNric = COMMAND_WORD + " " + PREFIX_NRIC + VALID_NRIC_BOB + " " +
-                PREFIX_PHONE + VALID_PHONE_BOB + " " + PREFIX_NAME + VALID_NAME_BOB;
-        EditCommand expectedCommandWithNric = new EditCommand(new Name(VALID_NAME_BOB), new Nric(VALID_NRIC_BOB), descriptor);
+        String validInputWithNric = COMMAND_WORD + " " + PREFIX_NRIC + VALID_NRIC_BOB + " "
+                + PREFIX_PHONE + VALID_PHONE_BOB + " " + PREFIX_NAME + VALID_NAME_BOB;
+        EditCommand expectedCommandWithNric = new EditCommand(new Name(VALID_NAME_BOB),
+                new Nric(VALID_NRIC_BOB), descriptor);
         assertEquals(parser.parse(validInputWithNric), expectedCommandWithNric);
 
         // Valid input with Name
-        String validInputWithName = COMMAND_WORD + " " + PREFIX_NAME  + VALID_NAME_AMY + " "
+        String validInputWithName = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_AMY + " "
                 + PREFIX_EMAIL + VALID_EMAIL_AMY;
         EditCommand expectedCommandWithName = new EditCommand(new Name(VALID_NAME_AMY), null, descriptor);
         assertEquals(parser.parse(validInputWithName), expectedCommandWithName);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -20,13 +20,17 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MEDICALHISTORY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.EditCommand.COMMAND_WORD;
 import static seedu.address.logic.commands.EditCommand.MESSAGE_NOT_EDITED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICAL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -59,7 +63,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no field specified
-        assertParseFailure(parser, "n/" + VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_NAME + VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no name or nric and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -68,15 +72,15 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "n/" + VALID_NAME_AMY + " some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_NAME + VALID_NAME_AMY + " some random string", MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "n/" + VALID_NAME_AMY + " i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_NAME + VALID_NAME_AMY + " i/ string", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = "edit " + "n/" + VALID_NAME_BOB + PHONE_DESC_BOB + TAG_DESC_HUSBAND
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
@@ -89,7 +93,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        String userInput = "edit " + "n/" + VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
@@ -101,37 +105,39 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // phone
-        String userInput = "edit " + "n/" + VALID_NAME_BOB + PHONE_DESC_AMY;
+        String userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
         EditCommand expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = "edit " + "n/" + VALID_NAME_BOB + EMAIL_DESC_AMY;
+        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
-        userInput = "edit " + "n/" + VALID_NAME_BOB + ADDRESS_DESC_AMY;
+        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = "edit " + "n/" + VALID_NAME_BOB + TAG_DESC_FRIEND;
+        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // medical
-        userInput = "edit " + "n/" + VALID_NAME_BOB + " m/cancer";
+        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_BOB + " "
+                + PREFIX_MEDICAL + VALID_MEDICALHISTORY;
         descriptor = new EditPersonDescriptorBuilder().withMedicalHistories(VALID_MEDICALHISTORY).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // appointment
-        userInput = "edit " + "n/" + VALID_NAME_AMY + " ap/" + VALID_APPOINTMENT;
+        userInput = COMMAND_WORD + " " +  PREFIX_NAME + VALID_NAME_AMY + " "
+                + PREFIX_APPOINTMENT + VALID_APPOINTMENT;
         descriptor = new EditPersonDescriptorBuilder().withAppointment(VALID_APPOINTMENT).build();
         expectedCommand = new EditCommand(new Name(VALID_NAME_AMY), null, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -140,13 +146,13 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecifiedUsingID_success() {
         // phone
-        String userInput = "edit " + "id/" + VALID_NRIC + PHONE_DESC_AMY;
+        String userInput = COMMAND_WORD + " " + PREFIX_NRIC + VALID_NRIC + PHONE_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
         EditCommand expectedCommand = new EditCommand(null, new Nric(VALID_NRIC), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = "edit " + "id/" + VALID_NRIC + EMAIL_DESC_AMY;
+        userInput = COMMAND_WORD + " " + PREFIX_NRIC + VALID_NRIC + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
         expectedCommand = new EditCommand(null, new Nric(VALID_NRIC), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -155,21 +161,19 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_failure() {
-        // More extensive testing of duplicate parameter detections is done in
-        // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
         // valid followed by invalid
-        String userInput = "edit " + "n/" + VALID_NAME_BOB + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // invalid followed by valid
-        userInput = "edit " + "n/" + VALID_NAME_BOB + PHONE_DESC_BOB + INVALID_PHONE_DESC;
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // mulltiple valid fields repeated
-        userInput = "edit " + "n/" + VALID_NAME_BOB + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB;
 
@@ -177,7 +181,7 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
 
         // multiple invalid values
-        userInput = "edit " + "n/" + VALID_NAME_BOB + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
+        userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
                 + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
@@ -186,7 +190,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        String userInput = "edit" + " n/" + VALID_NAME_BOB + TAG_EMPTY;
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
         EditCommand expectedCommand = new EditCommand(new Name(VALID_NAME_BOB), null, descriptor);
@@ -196,14 +200,14 @@ public class EditCommandParserTest {
 
     @Test
     public void parser_noFieldsProvided_failure() {
-        String userInput = "edit" + " n/" + VALID_NAME_BOB;
+        String userInput = COMMAND_WORD + " " + PREFIX_NAME + VALID_NAME_BOB;
 
         assertParseFailure(parser, userInput, MESSAGE_NOT_EDITED);
     }
     @Test
     public void parse_invalidInput_throwsParseException() {
         // Missing NAME or NRIC prefix
-        String invalidInput = " edit " + INVALID_EMAIL_DESC;
+        String invalidInput = COMMAND_WORD + " " + INVALID_EMAIL_DESC;
         assertThrows(ParseException.class, () -> parser.parse(invalidInput));
     }
 
@@ -211,14 +215,15 @@ public class EditCommandParserTest {
     public void parse_validInput_returnsEditCommand() throws ParseException {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
         // Valid input with NRIC
-        String validInputWithNric = " edit " + PREFIX_NRIC + "S1234567A " + PREFIX_PHONE + "91234567 "
-                + PREFIX_NAME + "John Doe";
-        EditCommand expectedCommandWithNric = new EditCommand(new Name("John Doe"), new Nric("S1234567A"), descriptor);
+        String validInputWithNric = COMMAND_WORD + " " + PREFIX_NRIC + VALID_NRIC_BOB + " " +
+                PREFIX_PHONE + VALID_PHONE_BOB + " " + PREFIX_NAME + VALID_NAME_BOB;
+        EditCommand expectedCommandWithNric = new EditCommand(new Name(VALID_NAME_BOB), new Nric(VALID_NRIC_BOB), descriptor);
         assertEquals(parser.parse(validInputWithNric), expectedCommandWithNric);
 
         // Valid input with Name
-        String validInputWithName = " edit " + PREFIX_NAME + "Alice " + PREFIX_EMAIL + "alice@example.com";
-        EditCommand expectedCommandWithName = new EditCommand(new Name("Alice"), null, descriptor);
+        String validInputWithName = COMMAND_WORD + " " + PREFIX_NAME  + VALID_NAME_AMY + " "
+                + PREFIX_EMAIL + VALID_EMAIL_AMY;
+        EditCommand expectedCommandWithName = new EditCommand(new Name(VALID_NAME_AMY), null, descriptor);
         assertEquals(parser.parse(validInputWithName), expectedCommandWithName);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -42,5 +42,4 @@ public class FindCommandParserTest {
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n id/T0100606Z \n \t T0206006Z  \t", expectedFindCommand);
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,12 +1,21 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.UndoCommand.INVALID_STEPS_TO_UNDO;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import java.text.ParseException;
+import java.util.Arrays;
 
 public class UndoCommandParserTest {
 
@@ -23,5 +32,44 @@ public class UndoCommandParserTest {
         assertParseFailure(parser, "abc", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
     }
 
-    //need add for positive
+    @Test
+    public void parse_validSteps_success(){
+        UndoCommand expectedUndoCommand = new UndoCommand(3);
+        assertParseSuccess(parser, "3", expectedUndoCommand);
+
+        expectedUndoCommand = new UndoCommand(999);
+        assertParseSuccess(parser, "999", expectedUndoCommand);
+    }
+
+    @Test
+    public void equals_sameObject_returnsTrue() {
+        UndoCommand command = new UndoCommand(3);
+        assertTrue(command.equals(command));
+    }
+
+    @Test
+    public void equals_equalStepsToUndo_returnsTrue() {
+        UndoCommand command1 = new UndoCommand(3);
+        UndoCommand command2 = new UndoCommand(3);
+        assertTrue(command1.equals(command2));
+    }
+
+    @Test
+    public void equals_differentStepsToUndo_returnsFalse() {
+        UndoCommand command1 = new UndoCommand(3);
+        UndoCommand command2 = new UndoCommand(4);
+        assertFalse(command1.equals(command2));
+    }
+
+    @Test
+    public void equals_null_returnsFalse() {
+        UndoCommand command = new UndoCommand(3);
+        assertFalse(command.equals(null));
+    }
+
+    @Test
+    public void equals_differentType_returnsFalse() {
+        UndoCommand command = new UndoCommand(3);
+        assertFalse(command.equals("This is a string"));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -10,12 +9,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.UndoCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-
-import java.text.ParseException;
-import java.util.Arrays;
 
 public class UndoCommandParserTest {
 
@@ -33,7 +27,7 @@ public class UndoCommandParserTest {
     }
 
     @Test
-    public void parse_validSteps_success(){
+    public void parse_validSteps_success() {
         UndoCommand expectedUndoCommand = new UndoCommand(3);
         assertParseSuccess(parser, "3", expectedUndoCommand);
 

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -22,4 +22,6 @@ public class UndoCommandParserTest {
     public void parse_nonNumericInput_throwsParseException() {
         assertParseFailure(parser, "abc", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
     }
+
+    //need add for positive
 }

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.UndoCommand.INVALID_STEPS_TO_UNDO;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UndoCommand;
+
+public class UndoCommandParserTest {
+
+    private final UndoCommandParser parser = new UndoCommandParser();
+
+    @Test
+    public void parse_invalidSteps_throwsParseException() {
+        assertParseFailure(parser, "-9", String.format(INVALID_STEPS_TO_UNDO));
+        assertParseFailure(parser, "0", String.format(INVALID_STEPS_TO_UNDO));
+    }
+
+    @Test
+    public void parse_nonNumericInput_throwsParseException() {
+        assertParseFailure(parser, "abc", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -2,7 +2,6 @@ package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -159,7 +157,7 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void popCommandFromHistory_nonEmptyStack_returnsCommandInLIFOOrder() {
+    public void popCommandFromHistory_nonEmptyStack_returnsCommand() {
         ModelManager modelManager = new ModelManager();
 
         AddCommand addCommand = new AddCommand(ALICE);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -11,10 +12,14 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.EmptyStackException;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -133,5 +138,48 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+    }
+
+    @Test
+    public void isCommandHistoryEmpty_emptyStack_returnsTrue() {
+        ModelManager modelManager = new ModelManager();
+        assertTrue(modelManager.isCommandHistoryEmpty());
+    }
+
+    @Test
+    public void popCommandFromHistory_emptyStack_exception() {
+        ModelManager modelManager = new ModelManager();
+        assertThrows(EmptyStackException.class, modelManager::popCommandFromHistory);
+    }
+
+    @Test
+    public void getCommandHistorySize_emptyStack_returnsZero() {
+        ModelManager modelManager = new ModelManager();
+        assertEquals(0, modelManager.getCommandHistorySize());
+    }
+
+    @Test
+    public void popCommandFromHistory_nonEmptyStack_returnsCommandInLIFOOrder() {
+        ModelManager modelManager = new ModelManager();
+
+        AddCommand addCommand = new AddCommand(ALICE);
+        ClearCommand clearCommand = new ClearCommand();
+        modelManager.addToHistory(addCommand);
+        modelManager.addToHistory(clearCommand);
+
+        assertEquals(clearCommand, modelManager.popCommandFromHistory());
+        assertEquals(addCommand, modelManager.popCommandFromHistory());
+    }
+
+    @Test
+    public void getCommandHistorySize_nonEmptyStack_returnsCorrectSize() {
+        ModelManager modelManager = new ModelManager();
+        
+        AddCommand addCommand = new AddCommand(ALICE);
+        ClearCommand clearCommand = new ClearCommand();
+        modelManager.addToHistory(addCommand);
+        modelManager.addToHistory(clearCommand);
+
+        assertEquals(2, modelManager.getCommandHistorySize());
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -174,7 +174,7 @@ public class ModelManagerTest {
     @Test
     public void getCommandHistorySize_nonEmptyStack_returnsCorrectSize() {
         ModelManager modelManager = new ModelManager();
-        
+
         AddCommand addCommand = new AddCommand(ALICE);
         ClearCommand clearCommand = new ClearCommand();
         modelManager.addToHistory(addCommand);


### PR DESCRIPTION
As of the PR, the following commands can be undone:
1. Clear
2. Edit
3. Add
4. Delete (For both deleting patient and deleting a patient's field)

*Some refactoring was also done in this PR

~~Do **NOT** merge yet. I have yet to add sufficient test cases.~~

Implementation:
1. A new Abstract class UndoableCommand with an abstract undo() method is created which extends from Command. The 4 undoable commands classes now extend from the new class instead of Command.
2. In order to supplement the undo feature, a stack of <UndoableCommand> and the relevant stack methods are added to the ModelManager class. Only after a command has been executed successfully, it will be added to the stack if it is an undoable command using the addToHistory method.
3. New fields to keep track of  the differing 'states' of the patients were added to the 4 undoable commands classes from which the undo method can utilize to revert the command. e.g editCommand class now stores the original patient and edited patient as fields now.
