### PR TITLE
Enhance Delete Command and Delete Command Parser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICAL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -34,7 +33,6 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_APPOINTMENT + "APPOINTMENT] "
-            + "[" + PREFIX_TAG + "TAG]..."
             + "[" + PREFIX_MEDICAL + "MEDICAL_HISTORY]...\n"
             + "Example 1: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -42,20 +40,18 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_APPOINTMENT + "2023-10-17 11:00 13:00 "
+            + PREFIX_APPOINTMENT + "17-10-2023 11:00 13:00 "
             + PREFIX_MEDICAL + "hypochondriac "
             + PREFIX_MEDICAL + "on Medicine XYZ "
-            + PREFIX_TAG + "owesMoney \n"
             + "Example 2: " + COMMAND_WORD_ALIAS + " "
-            + PREFIX_NAME + "Alex Yeoh"
+            + PREFIX_NAME + "Alex Yeoh "
             + PREFIX_NRIC + "S6742632F "
             + PREFIX_PHONE + "85743822 "
             + PREFIX_EMAIL + "alex@example.com "
             + PREFIX_ADDRESS + "420, Country Road, #02-25 "
-            + PREFIX_APPOINTMENT + "2023-11-10 11:00 13:00 "
+            + PREFIX_APPOINTMENT + "10-11-2023 11:00 13:00 "
             + PREFIX_MEDICAL + "tachycardia "
-            + PREFIX_MEDICAL + "on Medicine CHS "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_MEDICAL + "on Medicine CHS ";
 
     public static final String MESSAGE_SUCCESS = "New Patient added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This Patient already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,7 +35,8 @@ public class DeleteCommand extends UndoableCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " or " + COMMAND_WORD_ALIAS
             + ": Delete the patient identified by the full name or nric of the patient.\n"
             + "Parameters: n/Name or id/Nric (must be valid)\n"
-            + "Example 1: " + COMMAND_WORD + " n/John Doe or " + COMMAND_WORD + " id/S1234567A \n"
+            + "Fields that can be deleted: ap/ (Appointment) m/ (Medical History) \n"
+            + "Example 1: " + COMMAND_WORD + " n/John Doe or " + COMMAND_WORD + " id/S1234567A " + "ap/ m/\n"
             + "Example 1: " + COMMAND_WORD_ALIAS + " n/Alex Yeoh or " + COMMAND_WORD_ALIAS + " id/T0123456F";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Patient: %1$s";
@@ -62,8 +64,10 @@ public class DeleteCommand extends UndoableCommand {
     private final DeletePersonDescriptor deletePersonDescriptor;
 
     /**
-     * @param nric of the person in the filtered person list to edit
-     * @param name of the person in the filtered person list to edit
+     * @param nric                   of the person in the filtered person list to
+     *                               edit
+     * @param name                   of the person in the filtered person list to
+     *                               edit
      * @param deletePersonDescriptor details to delete the person with
      */
     public DeleteCommand(Nric nric, Name name, DeletePersonDescriptor deletePersonDescriptor) {
@@ -160,6 +164,10 @@ public class DeleteCommand extends UndoableCommand {
         Appointment updatedAppointment = personToEdit.getAppointment().isPresent() ? personToEdit.getAppointment().get()
                 : null;
 
+        if (deletePersonDescriptor.getMedicalHistory()) {
+            updatedMedicalHistories = new HashSet<MedicalHistory>();
+        }
+
         if (deletePersonDescriptor.getAppointment()) {
             updatedAppointment = null;
         }
@@ -169,73 +177,38 @@ public class DeleteCommand extends UndoableCommand {
     }
 
     /**
-     * Stores the boolean value of the fields that is to be deleted from a person in
-     * the address book.
+     * Stores the boolean value of the fields that is to be deleted from a patient
+     * in
+     * HealthSync.
      */
     public static class DeletePersonDescriptor {
-        private boolean phone;
-        private boolean medicalHistory;
-        private boolean appointment;
-        private boolean email;
-        private boolean address;
-        private boolean tags;
+        private boolean shouldDeleteAppointment;
+        private boolean shoudlDeleteMedicalHistory;
 
         public DeletePersonDescriptor() {
         }
 
-        public void setPhone() {
-            this.phone = true;
-        }
-
-        public boolean getPhone() {
-            return this.phone;
-        }
-
-        public void setEmail() {
-            this.email = true;
-        }
-
-        public boolean getEmail() {
-            return this.email;
-        }
-
-        public void setAddress() {
-            this.address = true;
-        }
-
-        public boolean getAddress() {
-            return this.address;
-        }
-
         public void setMedicalHistory() {
-            this.medicalHistory = true;
+            this.shoudlDeleteMedicalHistory = true;
         }
 
         public boolean getMedicalHistory() {
-            return this.medicalHistory;
+            return this.shoudlDeleteMedicalHistory;
         }
 
         public void setAppointment() {
-            this.appointment = true;
+            this.shouldDeleteAppointment = true;
         }
 
         public boolean getAppointment() {
-            return this.appointment;
-        }
-
-        public void setTags() {
-            this.tags = true;
-        }
-
-        public boolean getTags() {
-            return this.tags;
+            return this.shouldDeleteAppointment;
         }
 
         /**
          * Returns true if all fields are false.
          */
         public boolean isAllFalse() {
-            return !(phone || email || address || tags || medicalHistory || appointment);
+            return !(shoudlDeleteMedicalHistory || shouldDeleteAppointment);
         }
 
         @Override
@@ -250,23 +223,16 @@ public class DeleteCommand extends UndoableCommand {
             }
 
             DeletePersonDescriptor otherDeletePersonDescriptor = (DeletePersonDescriptor) other;
-            return Objects.equals(phone, otherDeletePersonDescriptor.phone)
-                    && Objects.equals(email, otherDeletePersonDescriptor.email)
-                    && Objects.equals(address, otherDeletePersonDescriptor.address)
-                    && Objects.equals(tags, otherDeletePersonDescriptor.tags)
-                    && Objects.equals(medicalHistory, otherDeletePersonDescriptor.medicalHistory)
-                    && Objects.equals(appointment, otherDeletePersonDescriptor.appointment);
+            return Objects.equals(shoudlDeleteMedicalHistory,
+                    otherDeletePersonDescriptor.shoudlDeleteMedicalHistory)
+                    && Objects.equals(shouldDeleteAppointment, otherDeletePersonDescriptor.shouldDeleteAppointment);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
-                    .add("phone", phone)
-                    .add("email", email)
-                    .add("address", address)
-                    .add("tags", tags)
-                    .add("medicalHistory", medicalHistory)
-                    .add("appointment", appointment)
+                    .add("shoudlDeleteMedicalHistory", shoudlDeleteMedicalHistory)
+                    .add("shouldDeleteAppointment", shouldDeleteAppointment)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteCommand.DeletePersonDescriptor;
@@ -32,11 +33,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NRIC, PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_APPOINTMENT, PREFIX_MEDICAL, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NRIC,
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_APPOINTMENT, PREFIX_MEDICAL, PREFIX_TAG);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_NRIC, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_APPOINTMENT, PREFIX_MEDICAL, PREFIX_TAG);
+        if (isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG)
+                || !isAnyPrefixPresent(argMultimap, PREFIX_NAME, PREFIX_NRIC, PREFIX_APPOINTMENT, PREFIX_MEDICAL)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_NRIC, PREFIX_APPOINTMENT, PREFIX_MEDICAL);
 
         boolean hasNamePrefix = argMultimap.getValue(PREFIX_NAME).isPresent();
         boolean hasNricPrefix = argMultimap.getValue(PREFIX_NRIC).isPresent();
@@ -56,6 +61,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
 
         DeletePersonDescriptor deletePersonDescriptor = new DeletePersonDescriptor();
+
+        if (argMultimap.prefixExist(PREFIX_MEDICAL)) {
+            deletePersonDescriptor.setMedicalHistory();
+        }
 
         if (argMultimap.prefixExist(PREFIX_APPOINTMENT)) {
             deletePersonDescriptor.setAppointment();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -9,9 +9,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -59,13 +59,5 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         return new FindCommand(findCommandPredicate);
-    }
-
-    /**
-     * Returns true if at least 1 of the prefixes isn't the empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean isAnyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -201,5 +202,13 @@ public class ParserUtil {
             historiesSet.add(parseMedical(historyName));
         }
         return historiesSet;
+    }
+
+    /**
+     * Returns true if at least 1 of the prefixes isn't the empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean isAnyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -101,18 +101,10 @@ public class DeleteCommandTest {
         DeletePersonDescriptor descriptor = new DeletePersonDescriptor();
 
         descriptor.setAppointment();
-        descriptor.setAddress();
-        descriptor.setEmail();
         descriptor.setMedicalHistory();
-        descriptor.setPhone();
-        descriptor.setTags();
 
         assertTrue(descriptor.getAppointment());
-        assertTrue(descriptor.getAddress());
-        assertTrue(descriptor.getEmail());
         assertTrue(descriptor.getMedicalHistory());
-        assertTrue(descriptor.getPhone());
-        assertTrue(descriptor.getTags());
     }
 
     @Test
@@ -172,7 +164,7 @@ public class DeleteCommandTest {
 
         // different person -> returns false
         DeletePersonDescriptor descriptorDifferent = new DeletePersonDescriptor();
-        descriptorDifferent.setAddress();
+        descriptorDifferent.setAppointment();
         assertFalse(descriptor.equals(descriptorDifferent));
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -46,12 +46,28 @@ public class DeleteCommandParserTest {
     }
 
     @Test
-    public void test_parse_descriptor() {
+    public void test_parse_descriptorAppointment() {
         String userString = " id/" + PersonBuilder.DEFAULT_NRIC + " ap/";
         DeletePersonDescriptor descriptor = new DeletePersonDescriptor();
         descriptor.setAppointment();
         DeleteCommand deleteCommand = new DeleteCommand(defaultNric, null, descriptor);
         assertParseSuccess(parser, userString, deleteCommand);
+    }
+
+    @Test
+    public void test_parse_descriptorMedicalHistory() {
+        String userString = " id/" + PersonBuilder.DEFAULT_NRIC + " m/";
+        DeletePersonDescriptor descriptor = new DeletePersonDescriptor();
+        descriptor.setMedicalHistory();
+        DeleteCommand deleteCommand = new DeleteCommand(defaultNric, null, descriptor);
+        assertParseSuccess(parser, userString, deleteCommand);
+    }
+
+    @Test
+    public void test_parse_descriptorInvalidField() {
+        String userString = "id/ " + PersonBuilder.DEFAULT_NRIC + " p/";
+        assertParseFailure(parser, userString,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -327,5 +329,29 @@ public class ParserUtilTest {
                         new MedicalHistory(VALID_MEDICAL_HISTORY_2)));
 
         assertEquals(expectedMedSet, actualMedSet);
+    }
+
+    @Test
+    public void testIsAnyPrefixPresent() {
+        // Create an ArgumentMultimap with some values
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(new Prefix("phone"), "123456789");
+        argumentMultimap.put(new Prefix("email"), "john@example.com");
+
+        // Test with prefixes that exist in the ArgumentMultimap
+        boolean result1 = isAnyPrefixPresent(argumentMultimap, new Prefix("phone"), new Prefix("email"));
+        assertTrue(result1);
+
+        // Test with prefixes that do not exist in the ArgumentMultimap
+        boolean result2 = isAnyPrefixPresent(argumentMultimap, new Prefix("address"), new Prefix("tags"));
+        assertFalse(result2);
+
+        // Test with a mix of existing and non-existing prefixes
+        boolean result3 = isAnyPrefixPresent(argumentMultimap, new Prefix("phone"), new Prefix("address"));
+        assertTrue(result3);
+
+        // Test with no prefixes
+        boolean result4 = isAnyPrefixPresent(argumentMultimap);
+        assertFalse(result4);
     }
 }


### PR DESCRIPTION
1. Delete can now delete entire medical history using m/ (Feature to delete specific medical history will be coming soon).
2. Rename fields in `DeletePersonDescriptor` to sound more like boolean.
3. Move method `isAnyPrefixPresent` to `ParserUtil.java`.
4. Add checks in `DeleteCommandParser` to check for invalid prefixes.
5. Update appointment format in `AddCommand's MESSAGE_USAGE`