### PR TITLE
Fix bugs from PE-D for email and messages.

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -64,7 +64,6 @@ public class Messages {
             builder.append("N/A;");
         } else {
             person.getMedicalHistories().forEach(builder::append);
-            builder.append(";");
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,30 +13,32 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-        public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-        public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-        public static final String MESSAGE_INVALID_ID = "Please provide a valid ID";
-        public static final String MESSAGE_INVALID_NAME = "Please provide a valid Name";
-        public static final String MESSAGE_INVALID_ID_AND_NAME = "Please provide either a valid ID or Name";
-        public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The patient index provided is invalid";
-        public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
-        public static final String MESSAGE_NO_PATIENT_FOUND = "No such patient found!";
-        public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following single-valued field(s): ";
-        public static final String MESSAGE_EMPTY_FIND_RESULT = "There are no FindCommand results. There is nothing to be saved to the logger tab.";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_ID = "Please provide a valid ID";
+    public static final String MESSAGE_INVALID_NAME = "Please provide a valid Name";
+    public static final String MESSAGE_INVALID_ID_AND_NAME = "Please provide either a valid ID or Name";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The patient index provided is invalid";
+    public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
+    public static final String MESSAGE_NO_PATIENT_FOUND = "No such patient found!";
+    public static final String MESSAGE_DUPLICATE_FIELDS =
+            "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_EMPTY_FIND_RESULT =
+            "There are no FindCommand results. There is nothing to be saved to the logger tab.";
 
-        public static final String MESSAGE_EMPTY_LOG = "No previous log to undo.";
+    public static final String MESSAGE_EMPTY_LOG = "No previous log to undo.";
 
-        /**
-         * Returns an error message indicating the duplicate prefixes.
-         */
-        public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
-                assert duplicatePrefixes.length > 0;
+    /**
+     * Returns an error message indicating the duplicate prefixes.
+     */
+    public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
+        assert duplicatePrefixes.length > 0;
 
-                Set<String> duplicateFields = Stream.of(duplicatePrefixes).map(Prefix::toString)
-                                .collect(Collectors.toSet());
+        Set<String> duplicateFields = Stream.of(duplicatePrefixes).map(Prefix::toString)
+                .collect(Collectors.toSet());
 
-                return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
-        }
+        return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+    }
 
     /**
      * Formats the {@code person} for display to the user.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.person.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -12,33 +13,30 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_ID = "Please provide a valid ID";
-    public static final String MESSAGE_INVALID_NAME = "Please provide a valid Name";
-    public static final String MESSAGE_INVALID_ID_AND_NAME = "Please provide either a valid ID or Name";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The patient index provided is invalid";
-    public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
-    public static final String MESSAGE_NO_PATIENT_FOUND = "No such patient found!";
-    public static final String MESSAGE_DUPLICATE_FIELDS =
-            "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_EMPTY_FIND_RESULT =
-            "There are no FindCommand results. There is nothing to be saved to the logger tab.";
+        public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+        public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+        public static final String MESSAGE_INVALID_ID = "Please provide a valid ID";
+        public static final String MESSAGE_INVALID_NAME = "Please provide a valid Name";
+        public static final String MESSAGE_INVALID_ID_AND_NAME = "Please provide either a valid ID or Name";
+        public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The patient index provided is invalid";
+        public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
+        public static final String MESSAGE_NO_PATIENT_FOUND = "No such patient found!";
+        public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following single-valued field(s): ";
+        public static final String MESSAGE_EMPTY_FIND_RESULT = "There are no FindCommand results. There is nothing to be saved to the logger tab.";
 
-    public static final String MESSAGE_EMPTY_LOG =
-            "No previous log to undo.";
+        public static final String MESSAGE_EMPTY_LOG = "No previous log to undo.";
 
-    /**
-     * Returns an error message indicating the duplicate prefixes.
-     */
-    public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
-        assert duplicatePrefixes.length > 0;
+        /**
+         * Returns an error message indicating the duplicate prefixes.
+         */
+        public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
+                assert duplicatePrefixes.length > 0;
 
-        Set<String> duplicateFields =
-                Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
+                Set<String> duplicateFields = Stream.of(duplicatePrefixes).map(Prefix::toString)
+                                .collect(Collectors.toSet());
 
-        return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
-    }
+                return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+        }
 
     /**
      * Formats the {@code person} for display to the user.
@@ -57,10 +55,15 @@ public class Messages {
                 .append(person.getAddress())
                 .append(";\n")
                 .append("Appointment: ")
-                .append(person.getAppointment().orElse(person.getAppointment().orElse(null)))
+                .append(person.getAppointment().map(Appointment::toString).orElse("N/A"))
                 .append("; Medical Histories: ");
 
-        person.getMedicalHistories().forEach(builder::append);
+        if (person.getMedicalHistories().isEmpty()) {
+            builder.append("N/A;");
+        } else {
+            person.getMedicalHistories().forEach(builder::append);
+            builder.append(";");
+        }
         return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,14 +10,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain.tld and adhere"
-            + "to the following constraints:\n"
+    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format"
+            + " local-part@domain.tld (tld = top-level domain)"
+            + " and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters ("
             + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special characters.\n"
             + "2. This is followed by a '@' , a domain name, a '.', and the top-level domain (tld). "
             + "The domain name is made up of domain labels separated by periods.\n"
             + "The domain name must:\n"
-            + "    - end with a top-level domain (tld) which is at least 2 characters long\n"
+            + "    - end with a tld which is at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label and tld consist of alphanumeric characters,"
             + " separated only by hyphens, if any.";

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -22,8 +22,8 @@ public class Email {
             + "    - have each domain label and tld consist of alphanumeric characters,"
             + " separated only by hyphens, if any.";
     // Credit: OWASP Validation Regex Repository
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+"
-            + "[a-zA-Z]{2,}$";
+    private static final String VALIDATION_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@"
+            + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -22,7 +22,8 @@ public class Email {
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label and tld consist of alphanumeric characters,"
             + " separated only by hyphens, if any.";
-    // Code below is taken from https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+    // @author nubnubyas-reused
+    // Reused from https://owasp.org/www-community/OWASP_Validation_Regex_Repository
     private static final String VALIDATION_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@"
             + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -22,7 +22,7 @@ public class Email {
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label and tld consist of alphanumeric characters,"
             + " separated only by hyphens, if any.";
-    // Credit: OWASP Validation Regex Repository
+    // Code below is taken from https://owasp.org/www-community/OWASP_Validation_Regex_Repository
     private static final String VALIDATION_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@"
             + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,26 +10,20 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
-            + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
+    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain.tld and adhere"
+            + "to the following constraints:\n"
+            + "1. The local-part should only contain alphanumeric characters and these special characters ("
+            + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special characters.\n"
+            + "2. This is followed by a '@' , a domain name, a '.', and the top-level domain (tld). "
+            + "The domain name is made up of domain labels separated by periods.\n"
             + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
+            + "    - end with a top-level domain (tld) which is at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
-    // alphanumeric and special characters
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+            + "    - have each domain label and tld consist of alphanumeric characters,"
+            + " separated only by hyphens, if any.";
+    // Credit: OWASP Validation Regex Repository
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+"
+            + "[a-zA-Z]{2,}$";
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -42,24 +42,23 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example.com ")); // trailing space
         assertFalse(Email.isValidEmail("peterjack@@example.com")); // double '@' symbol
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
-        assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
         assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("peterjack@examplecom")); // missing top level domain
+        assertFalse(Email.isValidEmail("peterjack@.com")); // missing domain name
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("a@bc.cm")); // minimal
+        assertTrue(Email.isValidEmail("test@localhost.com")); // alphabets only
+        assertTrue(Email.isValidEmail("123@145.com")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +67,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +82,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }


### PR DESCRIPTION
Following changes are made:

1. `MedicalHistories` and `Appointment` now show `N/A` for empty values.
2. Change validation regex for `Email` (Credit: OWASP Validation Regex Repository). Ensure that there is a '.' for the domain.