### PR TITLE
Revert Changes on Medical History Validation

### DIFF
--- a/src/main/java/seedu/address/model/person/MedicalHistory.java
+++ b/src/main/java/seedu/address/model/person/MedicalHistory.java
@@ -9,17 +9,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class MedicalHistory {
 
-    public static final String MESSAGE_CONSTRAINTS = "Medical History can take any values, and it should not be blank."
-                                                    + "\nIt also should not be more than 50 characters long.";
+    public static final String MESSAGE_CONSTRAINTS = "Medical History can take any values, and it should not be blank.";
 
     /*
      * The first character of the Medical History must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
-     * The Medical History should not be more than 50 characters long.
-     * Took into account of the longest medical condition in the world, which is
-     * Pneumonoultramicroscopicsilicovolcanoconiosis, which is 45 characters long.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].{0,49}";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/person/MedicalHistoryTest.java
+++ b/src/test/java/seedu/address/model/person/MedicalHistoryTest.java
@@ -27,8 +27,6 @@ public class MedicalHistoryTest {
         // invalid medical history
         assertFalse(MedicalHistory.isValidMedicalHistory("")); // empty string
         assertFalse(MedicalHistory.isValidMedicalHistory(" ")); // spaces only
-        // more than 50 characters long, invalid long medical history
-        assertFalse(MedicalHistory.isValidMedicalHistory("PneumonoultramicroscopicsilicovolcanoconiosisMoreChars"));
 
         // valid medical history
         assertTrue(MedicalHistory.isValidMedicalHistory("Diabetes"));


### PR DESCRIPTION
In this PR:
- Removes 50 alphanumeric char validation for Medical History in `Main` and `Test` Code